### PR TITLE
Synchronize RGB Hex values from official Nord palette

### DIFF
--- a/src/xml/Nord.itermcolors
+++ b/src/xml/Nord.itermcolors
@@ -7,351 +7,351 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.25300124287605286</real>
+		<real>0.32156863808631897</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.19692185521125793</real>
+		<real>0.25882354378700256</real>
 		<key>Red Component</key>
-		<real>0.17621420323848724</real>
+		<real>0.23137255012989044</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.34168937802314758</real>
+		<real>0.41568627953529358</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.29435792565345764</real>
+		<real>0.3803921639919281</real>
 		<key>Red Component</key>
-		<real>0.68855589628219604</real>
+		<real>0.74901962280273438</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.47597441077232361</real>
+		<real>0.54901963472366333</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7002110481262207</real>
+		<real>0.7450980544090271</real>
 		<key>Red Component</key>
-		<real>0.57605421543121338</real>
+		<real>0.63921570777893066</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.47280269861221313</real>
+		<real>0.43921568989753723</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.75577855110168457</real>
+		<real>0.52941179275512695</real>
 		<key>Red Component</key>
-		<real>0.89902019500732422</real>
+		<real>0.81568628549575806</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.70459425449371338</real>
+		<real>0.67450982332229614</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.56080448627471924</real>
+		<real>0.5058823823928833</real>
 		<key>Red Component</key>
-		<real>0.43401443958282471</real>
+		<real>0.36862745881080627</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.61571133136749268</real>
+		<real>0.67843139171600342</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.47487166523933411</real>
+		<real>0.55686277151107788</real>
 		<key>Red Component</key>
-		<real>0.64283657073974609</real>
+		<real>0.70588237047195435</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.67779052257537842</real>
+		<real>0.73333334922790527</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.68614721298217773</real>
+		<real>0.73725491762161255</real>
 		<key>Red Component</key>
-		<real>0.49344515800476074</real>
+		<real>0.56078433990478516</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.94574689865112305</real>
+		<real>0.95686274766921997</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.92092084884643555</real>
+		<real>0.93725490570068359</real>
 		<key>Red Component</key>
-		<real>0.90727746486663818</real>
+		<real>0.92549020051956177</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.47597441077232361</real>
+		<real>0.54901963472366333</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.7002110481262207</real>
+		<real>0.7450980544090271</real>
 		<key>Red Component</key>
-		<real>0.57605421543121338</real>
+		<real>0.63921570777893066</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.47280269861221313</real>
+		<real>0.54509806632995605</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.75577855110168457</real>
+		<real>0.79607844352722168</real>
 		<key>Red Component</key>
-		<real>0.89902019500732422</real>
+		<real>0.92156863212585449</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.70459425449371338</real>
+		<real>0.75686275959014893</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.56080448627471924</real>
+		<real>0.63137257099151611</real>
 		<key>Red Component</key>
-		<real>0.43401443958282471</real>
+		<real>0.5058823823928833</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.61571133136749268</real>
+		<real>0.67843139171600342</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.47487166523933411</real>
+		<real>0.55686277151107788</real>
 		<key>Red Component</key>
-		<real>0.64283657073974609</real>
+		<real>0.70588237047195435</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.77356863021850586</real>
+		<real>0.81568628549575806</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.70216643810272217</real>
+		<real>0.75294119119644165</real>
 		<key>Red Component</key>
-		<real>0.4660642147064209</real>
+		<real>0.53333336114883423</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.92620980739593506</real>
+		<real>0.94117647409439087</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8916594386100769</real>
+		<real>0.91372549533843994</real>
 		<key>Red Component</key>
-		<real>0.87367779016494751</real>
+		<real>0.89803922176361084</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.34064260125160217</real>
+		<real>0.41568627953529358</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.2652154266834259</real>
+		<real>0.33725491166114807</real>
 		<key>Red Component</key>
-		<real>0.23306176066398621</real>
+		<real>0.29803922772407532</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.34168937802314758</real>
+		<real>0.41568627953529358</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.29435792565345764</real>
+		<real>0.3803921639919281</real>
 		<key>Red Component</key>
-		<real>0.68855589628219604</real>
+		<real>0.74901962280273438</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.19183900952339172</real>
+		<real>0.25098040699958801</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.15255947411060333</real>
+		<real>0.20392157137393951</real>
 		<key>Red Component</key>
-		<real>0.1357133686542511</real>
+		<real>0.18039216101169586</real>
 	</dict>
 	<key>Badge Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>0.7057952880859375</real>
 		<key>Blue Component</key>
-		<real>0.29600727558135986</real>
+		<real>0.36862450838088989</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.23046499490737915</real>
+		<real>0.29803276062011719</real>
 		<key>Red Component</key>
-		<real>0.20252507925033569</real>
+		<real>0.26274728775024414</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.94574689865112305</real>
+		<real>0.95686274766921997</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.92092084884643555</real>
+		<real>0.93725490570068359</real>
 		<key>Red Component</key>
-		<real>0.90727746486663818</real>
+		<real>0.92549020051956177</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.89225924015045166</real>
+		<real>0.91372549533843994</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.83857882022857666</real>
+		<real>0.87058824300765991</real>
 		<key>Red Component</key>
-		<real>0.81214714050292969</real>
+		<real>0.84705883264541626</real>
 	</dict>
 	<key>Cursor Guide Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.25300124287605286</real>
+		<real>0.36862745881080627</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.19692185521125793</real>
+		<real>0.29803922772407532</real>
 		<key>Red Component</key>
-		<real>0.17621420323848724</real>
+		<real>0.26274511218070984</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.25300124287605286</real>
+		<real>0.32156863808631897</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.19692185521125793</real>
+		<real>0.25882354378700256</real>
 		<key>Red Component</key>
-		<real>0.17621420323848724</real>
+		<real>0.23137255012989044</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.89225912094116211</real>
+		<real>0.91372549533843994</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.83857882022857666</real>
+		<real>0.87058824300765991</real>
 		<key>Red Component</key>
-		<real>0.81214725971221924</real>
+		<real>0.84705883264541626</real>
 	</dict>
 	<key>Link Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.92620980739593506</real>
+		<real>0.94117647409439087</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.8916594386100769</real>
+		<real>0.91372549533843994</real>
 		<key>Red Component</key>
-		<real>0.87367779016494751</real>
+		<real>0.89803922176361084</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.89225924015045166</real>
+		<real>0.91372549533843994</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.83857882022857666</real>
+		<real>0.87058824300765991</real>
 		<key>Red Component</key>
-		<real>0.81214714050292969</real>
+		<real>0.84705883264541626</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.34064260125160217</real>
+		<real>0.36862745881080627</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.2652154266834259</real>
+		<real>0.29803922772407532</real>
 		<key>Red Component</key>
-		<real>0.23306176066398621</real>
+		<real>0.26274511218070984</real>
 	</dict>
 	<key>Tab Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.25300124287605286</real>
+		<real>0.32156863808631897</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.19692185521125793</real>
+		<real>0.25882354378700256</real>
 		<key>Red Component</key>
-		<real>0.17621420323848724</real>
+		<real>0.23137255012989044</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
```
Align the ANSI and other iTerm2 colors to the Nord color palette.

The following values have changed in the iTerm2 Settings > Profiles >
Colors panel, noting changes in colors:

Basic Colors
------------
- Foreground    (nord4): #d8dde8 -> #d8dee9
- Background    (nord0): #2e333f -> #2e3440
- Bold          (nord6): #eceef3 -> #eceff4
- Links         (nord5): #e5e8ef -> #e5e9f0
- Selection     (nord2): #4c5569 -> #434c5e
                         (nord3) -> (nord2)
- Selected text (nord4): #d8dde8 -> #d8dee9
- Tab color     (nord1): #3b4151 -> #3b4252

Cursor Colors
-------------
- Cursor       (nord4): #d8dde8 -> #d8dee9
- Cursor text  (nord1): #3b4151 -> #3b4252
- Cursor guide (nord2): #3b4151 -> #434c5e
                        (nord1)    (nord2)

ANSI Colors
-----------
- Normal Black     (nord1): #3b4151  -> #3b4252
- Bright Black     (nord3): #4c5569  -> #4c566a
- Normal Red      (nord11): #be6069  -> #bf616a
- Bright Red      (nord11): #be6069  -> #bf616a
- Normal Green    (nord14): #a3bd8b  -> #a3be8c
- Bright Green:   (nord14): #a3bd8b  -> #a3be8c
- Normal Yellow:  (nord13): #ebca8a  -> #ebcb8b
- Bright Yellow:  (nord12): #ebca8a  -> #d08770
                            (nord13)    (nord12)
- Normal Blue:     (nord9): #81a0c0  -> #81a1c1
- Bright Blue:    (nord10): #81a0c0  -> #5e81ac
                            (nord9)     (nord10)
- Normal Magenta: (nord15): #b48dac  -> #b48ead
- Bright Magenta: (nord15): #b48dac  -> #b48ead
- Normal Cyan:     (nord8): #88bfcf  -> #88c0d0
- Bright Cyan:     (nord7): #8fbbba  -> #8fbcbb
- Normal White:    (nord5): #e5e8ef  -> #e5e9f0
- Bright White:    (nord6): #eceef3  -> #eceff4

The text selection and cursor guide uses nord2 now to align with
"currently active text editor line as well as selection."

Bright Blue uses nord10, the next accent level, for tertiary UI
elements. Using nord12 may be a stretch for Bright Yellow. With both
these changes, all of Frost and Aurora are available.
```

Closes: #15 